### PR TITLE
Fix price of Rust.Tokyo

### DIFF
--- a/conferences.json
+++ b/conferences.json
@@ -66,7 +66,7 @@
         "features": {
             "duration": "1 day",
             "kind": "conference",
-            "price": "Free"
+            "price": "¥1,000 (students will receive 50% discount)"
         }
     },
     {

--- a/conferences.json
+++ b/conferences.json
@@ -66,7 +66,7 @@
         "features": {
             "duration": "1 day",
             "kind": "conference",
-            "price": "¥1,000 (students will receive 50% discount)"
+            "price": "¥500-¥1,000"
         }
     },
     {


### PR DESCRIPTION
In the [ticket page](https://ti.to/rust-tokyo/2019), they say:

- The regular ticket is ¥1,000 plus optional gratuity.
- The student ticket is ¥500.

![image](https://user-images.githubusercontent.com/41755/65371071-d64dad80-dc9a-11e9-8857-e49cb6f17cde.png)

cc: @dorayakikun @T5uku5hi @chikoski @yuk1ty