### PR TITLE
fix typo in location of RustFest Global 2020

### DIFF
--- a/conferences.json
+++ b/conferences.json
@@ -77,7 +77,7 @@
         "name": "RustFest Global 2020",
         "date": "2020-11-07T00:00:00+01:00",
         "blurb": "RustFest is the European Rust conference",
-        "location": "Online, Europa",
+        "location": "Online, Europe",
         "website": "//2020.rustfest.eu/",
         "schedule": "//2020.rustfest.eu/schedule",
         "cfp": {


### PR DESCRIPTION
Hi, 
i spotted a small typo in the location data for RustFest Global 2020.
Since the rest of the website is in English, the German spelling "Europa", instead of "Europe", seems out of place.

Thanks for your work in the Rust community :)