### PR TITLE
Remove wrong Oxidize CFP info

### DIFF
--- a/conferences.json
+++ b/conferences.json
@@ -135,10 +135,6 @@
         "location": "Remote",
         "website": "//oxidizeconf.com",
         "schedule": "//oxidizeconf.com/schedule/",
-        "cfp": {
-            "end": "2020-08-03T23:59:59+01:00",
-            "link": "//cfp.oxidizeconf.com/events/oxidize-2020"
-        },
         "features": {
             "duration": "3 day",
             "kind": "conference",


### PR DESCRIPTION
It was set to be after the conf. I doubt that's right.